### PR TITLE
fix: fix path separator in windows

### DIFF
--- a/news/fix-ci.rst
+++ b/news/fix-ci.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* No news added: Fix path separator mismatch for different platforms in the tests.
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>

--- a/tests/test_runmacro.py
+++ b/tests/test_runmacro.py
@@ -1,3 +1,4 @@
+import re
 from pathlib import Path
 
 import numpy
@@ -186,7 +187,7 @@ def test_command_processor(
         (
             'load structure foo from "/nonexistent/path.cif"',
             FileNotFoundError,
-            "structure /nonexistent/path.cif not found. "
+            f"structure {Path('/nonexistent/path.cif')} not found. "
             "Please ensure the path is correct and the file exists.",
         ),
         (
@@ -207,5 +208,5 @@ def test_command_processor(
 )
 def test_load_command_processor_bad(command_string, expected_exception, match):
     parser = MacroParser()
-    with pytest.raises(expected_exception, match=match):
+    with pytest.raises(expected_exception, match=re.escape(match)):
         parser.parse(command_string)


### PR DESCRIPTION
### What problem does this PR address?

<!-- Provide a brief overview and link to the issue. Attach outputs, including screenshots (before/after), if helpful for the reviewer. -->

Closes #16 

In the CI:
<img width="905" height="48" alt="image" src="https://github.com/user-attachments/assets/2a7da94a-0434-4523-b372-f3b43ab4b6c8" />

Fix path mismatch in the tests in windows.

### What should the reviewer(s) do?

Please check the modifications.

<!-- Merge the code, provide feedback, initiate a discussion, etc. -->

<!--
Use the following checklist items when applicable (select only what applies):
- [ ] This PR introduces a public-facing change (e.g., figures, CLI input/output, API).
    - [ ] Documentation (e.g., tutorials, examples, README) has been updated.
    - [ ] A tracking issue or plan to update documentation exists.
- [ ] This PR affects internal functionality only (no user-facing change).
-->
