### PR TITLE
fix: set `python>=3.11,<3.14`

### DIFF
--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -3,7 +3,7 @@
   "author_emails": "yx2924@columbia.edu, sbillinge@ucsb.edu",
   "maintainer_names": "Yuchen Xiao, Simon Billinge",
   "maintainer_emails": "yx2924@columbia.edu, sbillinge@ucsb.edu",
-  "maintainer_github_usernames": "ycexiao, sbillinge",
+  "maintainer_github_usernames": "sbillinge",
   "contributors": "Yuchen Xiao, Simon Billinge and members of the Billinge group",
   "license_holders": "diffpy.apps contributors",
   "project_name": "diffpy.apps",
@@ -13,8 +13,8 @@
   "package_dir_name": "diffpy.apps",
   "project_short_description": "User applications to help with tasks using diffpy packages",
   "project_keywords": "diffraction, PDF, X-ray, neutron",
-  "minimum_supported_python_version": "3.12",
-  "maximum_supported_python_version": "3.14",
+  "minimum_supported_python_version": "3.11",
+  "maximum_supported_python_version": "3.13",
   "project_needs_c_code_compiled": "No",
   "project_has_gui_tests": "No"
 }

--- a/news/python-version.rst
+++ b/news/python-version.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* No news added: Use ``python>=3.11,<3.14``.
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ maintainers = [
 description = "User applications to help with tasks using diffpy packages"
 keywords = ['diffraction', 'PDF', 'X-ray', 'neutron']
 readme = "README.rst"
-requires-python = ">=3.12, <3.15"
+requires-python = ">=3.11, <3.14"
 classifiers = [
         'Development Status :: 5 - Production/Stable',
         'Environment :: Console',
@@ -27,9 +27,9 @@ classifiers = [
         'Operating System :: Microsoft :: Windows',
         'Operating System :: POSIX',
         'Operating System :: Unix',
+        'Programming Language :: Python :: 3.11',
         'Programming Language :: Python :: 3.12',
         'Programming Language :: Python :: 3.13',
-        'Programming Language :: Python :: 3.14',
         'Topic :: Scientific/Engineering :: Physics',
         'Topic :: Scientific/Engineering :: Chemistry',
 ]


### PR DESCRIPTION
### What problem does this PR address?

<!-- Provide a brief overview and link to the issue. Attach outputs, including screenshots (before/after), if helpful for the reviewer. -->

The release workflow fails because `diffpy.cmi` doesn't support `python=3.14` https://github.com/diffpy/diffpy.apps/actions/runs/25756923231

### What should the reviewer(s) do?

<!-- Merge the code, provide feedback, initiate a discussion, etc. -->

<!--
Use the following checklist items when applicable (select only what applies):
- [ ] This PR introduces a public-facing change (e.g., figures, CLI input/output, API).
    - [ ] Documentation (e.g., tutorials, examples, README) has been updated.
    - [ ] A tracking issue or plan to update documentation exists.
- [ ] This PR affects internal functionality only (no user-facing change).
-->
