### PR TITLE
fix: tests failed when `git` is not installed

### DIFF
--- a/docs/source/getting-started.rst
+++ b/docs/source/getting-started.rst
@@ -25,7 +25,7 @@ diffpy macro language.
 
 .. code-block:: bash
 
-    diffpy.app runmacro <macro_file.dp-in>
+    diffpy-app runmacro <macro_file.dp-in>
 
 To follow the example,
 
@@ -43,7 +43,7 @@ To follow the example,
 
 .. code-block:: bash
 
-    diffpy.app runmacro example_macro.dp-in
+    diffpy-app runmacro example_macro.dp-in
 
 How to write macro
 ~~~~~~~~~~~~~~~~~~
@@ -160,23 +160,23 @@ local environment. To use this application, run:
 
 .. code-block:: bash
 
-    diffpy.app agentify
+    diffpy-app agentify
 
 ``claude`` and ``codex`` agent skills are supported, and ``claude`` is used
 by default. To specify the agent skill, use the ``--agent`` option:
 
 .. code-block:: bash
 
-    diffpy.app agentify --agent codex
+    diffpy-app agentify --agent codex
 
 To deploy the agentic skill to the system directory, use the ``--system`` flag:
 
 .. code-block:: bash
 
-    diffpy.app agentify --system
+    diffpy-app agentify --system
 
 To update the existing ``diffpy.cmi`` agentic skill, use the ``--update`` flag:
 
 .. code-block:: bash
 
-    diffpy.app agentify --update
+    diffpy-app agentify --update

--- a/news/skipif-no-internet.rst
+++ b/news/skipif-no-internet.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* Ensure ``git`` is installed and internet connection for ``agentify``.
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,8 +51,8 @@ exclude = []  # exclude packages matching these glob patterns (empty by default)
 namespaces = false  # to disable scanning PEP 420 namespaces (true by default)
 
 [project.scripts]
-"diffpy.apps" = "diffpy.apps.apps:main"
-"diffpy.app" = "diffpy.apps.apps:main"
+"diffpy-apps" = "diffpy.apps.apps:main"
+"diffpy-app" = "diffpy.apps.apps:main"
 
 [tool.setuptools.dynamic]
 dependencies = {file = ["requirements/pip.txt"]}

--- a/src/diffpy/apps/app_agentify.py
+++ b/src/diffpy/apps/app_agentify.py
@@ -1,4 +1,5 @@
 import shutil
+import socket
 import subprocess
 import tempfile
 from pathlib import Path
@@ -7,7 +8,27 @@ REPO_URL = "https://github.com/diffpy/cmi-agent-skills"
 DIR_NAME = "cmi-skill"
 
 
+def ensure_setup():
+    def internet_available():
+        try:
+            socket.create_connection(("github.com", 443), timeout=3)
+            return True
+        except OSError:
+            return False
+
+    git_available = shutil.which("git") is not None
+    agentify_available = internet_available() and git_available
+    return agentify_available
+
+
 def agentify(args):
+    if not ensure_setup():
+        print(
+            "Internet connection or git unavailable. "
+            "Please ensure git is installed and you have an active internet "
+            f"connection to {REPO_URL}."
+        )
+        return
     agent = args.agent
     system_flag = args.system
     if agent == "claude":

--- a/src/diffpy/apps/app_agentify.py
+++ b/src/diffpy/apps/app_agentify.py
@@ -23,12 +23,11 @@ def ensure_setup():
 
 def agentify(args):
     if not ensure_setup():
-        print(
+        raise ValueError(
             "Internet connection or git unavailable. "
             "Please ensure git is installed and you have an active internet "
             f"connection to {REPO_URL}."
         )
-        return
     agent = args.agent
     system_flag = args.system
     if agent == "claude":

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,4 @@
 import json
-import shutil
-import socket
 from pathlib import Path
 
 import pytest
@@ -19,15 +17,3 @@ def user_filesystem(tmp_path):
         json.dump(home_config_data, f)
 
     yield tmp_path
-
-
-def internet_available():
-    try:
-        socket.create_connection(("github.com", 443), timeout=3)
-        return True
-    except OSError:
-        return False
-
-
-git_available = shutil.which("git") is not None
-AGENTIFY_AVAILABLE = internet_available() and git_available

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,6 @@
 import json
+import shutil
+import socket
 from pathlib import Path
 
 import pytest
@@ -17,3 +19,15 @@ def user_filesystem(tmp_path):
         json.dump(home_config_data, f)
 
     yield tmp_path
+
+
+def internet_available():
+    try:
+        socket.create_connection(("github.com", 443), timeout=3)
+        return True
+    except OSError:
+        return False
+
+
+git_available = shutil.which("git") is not None
+AGENTIFY_AVAILABLE = internet_available() and git_available

--- a/tests/test_agentify.py
+++ b/tests/test_agentify.py
@@ -6,7 +6,13 @@ from unittest import mock
 
 import pytest
 
-from diffpy.apps.app_agentify import agentify
+from diffpy.apps.app_agentify import agentify, ensure_setup
+
+pytestmark = pytest.mark.skipif(
+    not ensure_setup(),
+    reason="Internet connection or git unavailable. Skipping agentify tests.",
+    allow_module_level=True,
+)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
- **fix: skip agentify tests when git or internet is unavailable**
- **feat: ensure `git` and internet connection**
- **fix: use `diffpy-app` instead of `diffpy.app`**

### What problem does this PR address?

The `Conda-forge` build failed: https://dev.azure.com/conda-forge/84710dde-1620-425b-80d0-4cf5baca359d/_apis/build/builds/1524931/logs/29

1. Ensure internet connection and `git` is installed  before running `agentry` to fetch skills.
2. `diffpy.app` is not working in macOS system because of the suffix `.app`. Use `diffpy-app` instead.

<!-- Provide a brief overview and link to the issue. Attach outputs, including screenshots (before/after), if helpful for the reviewer. -->

### What should the reviewer(s) do?

<!-- Merge the code, provide feedback, initiate a discussion, etc. -->

<!--
Use the following checklist items when applicable (select only what applies):
- [ ] This PR introduces a public-facing change (e.g., figures, CLI input/output, API).
    - [ ] Documentation (e.g., tutorials, examples, README) has been updated.
    - [ ] A tracking issue or plan to update documentation exists.
- [ ] This PR affects internal functionality only (no user-facing change).
-->
